### PR TITLE
Fixed compatibility with Blender version 4.3

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -161,7 +161,6 @@ def create_compify_material(name, camera, footage):
     mat = bpy.data.materials.new(name)
     mat.use_nodes = True
     mat.blend_method = 'HASHED'
-    mat.shadow_method = 'HASHED'
     for node in mat.node_tree.nodes:
         mat.node_tree.nodes.remove(node)
 


### PR DESCRIPTION
mat.shadow_method is removed from Blender 4.3