### PR TITLE
Support newer Blender material settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Blender addon for easier/better compositing in 3D space.
 
 This addon is currently beta quality.  There may still be major bugs and rough edges, but in general it should *basically* work.  Due to limitations in Blender's Python APIs there are also some rough edges that are unforunately impossible to fix at the moment.
 
-This addon requires Blender 4.0 or later.
+This addon requires Blender 4.0 through Blender 5.0.
 
 
 # License

--- a/__init__.py
+++ b/__init__.py
@@ -161,7 +161,10 @@ def create_compify_material(name, camera, footage):
     mat = bpy.data.materials.new(name)
     mat.use_nodes = True
     mat.blend_method = 'HASHED'
-    mat.shadow_method = 'HASHED'
+    if hasattr(mat, "shadow_method"):
+        mat.shadow_method = 'HASHED'
+    elif hasattr(mat, "surface_render_method"):
+        mat.surface_render_method = 'DITHERED'
     for node in mat.node_tree.nodes:
         mat.node_tree.nodes.remove(node)
 


### PR DESCRIPTION
Fixes material setup in Blender versions where `Material.shadow_method` is unavailable.

Updates the README compatibility line to Blender 4.0 through Blender 5.0.

Tested in Blender 4.0.0, 4.5.3 LTS, and 5.0.0.
